### PR TITLE
CompatHelper: bump compat for "Clang_jll" to "12"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,6 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
-Clang_jll = "^9,^11"
+Clang_jll = "^9,^11, 12"
 Scratch = "^1"
 julia = "^1.5"


### PR DESCRIPTION
This pull request changes the compat entry for the `Clang_jll` package from `^9,^11` to `^9,^11, 12`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.